### PR TITLE
Adds dot-notation support for the `state` method.

### DIFF
--- a/src/Actions/UndotArrayKeys.php
+++ b/src/Actions/UndotArrayKeys.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Actions;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Worksome\RequestFactories\Contracts\Actions\UndotsArrayKeys;
+
+final class UndotArrayKeys implements UndotsArrayKeys
+{
+    private string $placeholder;
+
+    public function __construct()
+    {
+        $this->placeholder = Str::random();
+    }
+
+    public function __invoke(array $array): array
+    {
+        $array = $this->replaceEscapedDotsWithPlaceholder($array);
+        $array = Arr::undot($array);
+
+        return $this->recursivelyReplacePlaceholderWithDots($array);
+    }
+
+    private function recursivelyReplacePlaceholderWithDots(array $array): array
+    {
+        $array = $this->replacePlaceholderWithDots($array);
+
+        foreach ($array as $key => $item) {
+            if (is_array($item)) {
+                $array[$key] = $this->recursivelyReplacePlaceholderWithDots($item);
+            }
+        }
+
+        return $array;
+    }
+
+    private function replaceEscapedDotsWithPlaceholder(array $array): array
+    {
+        $keys = array_map(fn ($key) => str_replace('\.', $this->placeholder, $key), array_keys($array));
+
+        return array_combine($keys, $array);
+    }
+
+    private function replacePlaceholderWithDots(array $array): array
+    {
+        $keys = array_map(fn ($key) => str_replace($this->placeholder, '.', $key), array_keys($array));
+
+        return array_combine($keys, $array);
+    }
+}

--- a/src/Contracts/Actions/UndotsArrayKeys.php
+++ b/src/Contracts/Actions/UndotsArrayKeys.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Contracts\Actions;
+
+/**
+ * @template TValue
+ */
+interface UndotsArrayKeys
+{
+    /**
+     * @param array<TValue> $array
+     * @return array<TValue>
+     */
+    public function __invoke(array $array): array;
+}

--- a/src/RequestFactoriesServiceProvider.php
+++ b/src/RequestFactoriesServiceProvider.php
@@ -8,11 +8,9 @@ use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\ServiceProvider;
 use Worksome\RequestFactories\Actions\CreateFactoryResult;
 use Worksome\RequestFactories\Actions\MergeFactoryIntoRequest;
-use Worksome\RequestFactories\Actions\UndotArrayKeys;
 use Worksome\RequestFactories\Commands\MakeCommand;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
 use Worksome\RequestFactories\Contracts\Actions\MergesFactoryIntoRequest;
-use Worksome\RequestFactories\Contracts\Actions\UndotsArrayKeys;
 use Worksome\RequestFactories\Contracts\Finder;
 use Worksome\RequestFactories\Support\ConfigBasedFinder;
 
@@ -22,7 +20,6 @@ final class RequestFactoriesServiceProvider extends ServiceProvider
     {
         $this->app->bind(CreatesFactoryResult::class, CreateFactoryResult::class);
         $this->app->bind(MergesFactoryIntoRequest::class, MergeFactoryIntoRequest::class);
-        $this->app->bind(UndotsArrayKeys::class, UndotArrayKeys::class);
         $this->app->singleton(Finder::class, fn () => new ConfigBasedFinder(config('request-factories')));
         $this->app->singleton(FactoryManager::class);
     }

--- a/src/RequestFactoriesServiceProvider.php
+++ b/src/RequestFactoriesServiceProvider.php
@@ -8,9 +8,11 @@ use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\ServiceProvider;
 use Worksome\RequestFactories\Actions\CreateFactoryResult;
 use Worksome\RequestFactories\Actions\MergeFactoryIntoRequest;
+use Worksome\RequestFactories\Actions\UndotArrayKeys;
 use Worksome\RequestFactories\Commands\MakeCommand;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
 use Worksome\RequestFactories\Contracts\Actions\MergesFactoryIntoRequest;
+use Worksome\RequestFactories\Contracts\Actions\UndotsArrayKeys;
 use Worksome\RequestFactories\Contracts\Finder;
 use Worksome\RequestFactories\Support\ConfigBasedFinder;
 
@@ -20,6 +22,7 @@ final class RequestFactoriesServiceProvider extends ServiceProvider
     {
         $this->app->bind(CreatesFactoryResult::class, CreateFactoryResult::class);
         $this->app->bind(MergesFactoryIntoRequest::class, MergeFactoryIntoRequest::class);
+        $this->app->bind(UndotsArrayKeys::class, UndotArrayKeys::class);
         $this->app->singleton(Finder::class, fn () => new ConfigBasedFinder(config('request-factories')));
         $this->app->singleton(FactoryManager::class);
     }

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -10,8 +10,9 @@ use Faker\Generator;
 use Illuminate\Http\Testing\File;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Arr;
+use Worksome\RequestFactories\Actions\UndotArrayKeys;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
+use Worksome\RequestFactories\Contracts\Actions\UndotsArrayKeys;
 use Worksome\RequestFactories\Support\FactoryData;
 
 abstract class RequestFactory
@@ -72,7 +73,7 @@ abstract class RequestFactory
      */
     public function state(array $attributes): static
     {
-        return $this->newInstance(attributes: Arr::undot($attributes));
+        return $this->newInstance(attributes: $this->getUndotsArrayKeysAction()($attributes));
     }
 
     /**
@@ -138,6 +139,11 @@ abstract class RequestFactory
     protected function faker(): Generator
     {
         return $this->faker;
+    }
+
+    protected function getUndotsArrayKeysAction(): UndotsArrayKeys
+    {
+        return new UndotArrayKeys();
     }
 
     protected function newInstance(

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -10,6 +10,7 @@ use Faker\Generator;
 use Illuminate\Http\Testing\File;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
 use Worksome\RequestFactories\Support\FactoryData;
 
@@ -71,7 +72,7 @@ abstract class RequestFactory
      */
     public function state(array $attributes): static
     {
-        return $this->newInstance(attributes: $attributes);
+        return $this->newInstance(attributes: Arr::undot($attributes));
     }
 
     /**

--- a/tests/Unit/Actions/UndotArrayKeysTest.php
+++ b/tests/Unit/Actions/UndotArrayKeysTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Worksome\RequestFactories\Actions\UndotArrayKeys;
+
+it('can undot an array key', function ($givenArray, $resultingArray) {
+    $action = new UndotArrayKeys();
+
+    $result = $action($givenArray);
+
+    expect($result)->toBe($resultingArray);
+})->with([
+    [
+        ['foo.bar' => 'baz'],
+        ['foo' => ['bar' => 'baz']]
+    ],
+    [
+        ['foo.bar.baz' => 'boom'],
+        ['foo' => ['bar' => ['baz' => 'boom']]],
+    ],
+    [
+        ['foo.bar' => 'baz', 'luke' => 'downing'],
+        ['foo' => ['bar' => 'baz'], 'luke' => 'downing'],
+    ]
+]);
+
+it('can escape dots with the \\ character', function ($givenArray, $resultingArray) {
+    $action = new UndotArrayKeys();
+
+    $result = $action($givenArray);
+
+    expect($result)->toBe($resultingArray);
+})->with([
+    [
+        ['foo\.bar' => 'baz'],
+        ['foo.bar' => 'baz']
+    ],
+    [
+        ['foo\.bar\.baz' => 'boom'],
+        ['foo.bar.baz' => 'boom'],
+    ],
+    [
+        ['foo.bar\.baz' => 'boom'],
+        ['foo' => ['bar.baz' => 'boom']],
+    ]
+]);

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -43,6 +43,12 @@ it('can alter nested properties using the state method and dot notation', functi
     expect($data['foo']['bar'])->toBe('boom');
 });
 
+it('can escape properties that should have dots in it', function () {
+    $data = creator(ExampleFormRequestFactory::new()->state(['foo\.bar' => 'baz']));
+
+    expect($data['foo.bar'])->toBe('baz');
+});
+
 it('can resolve nested form request factories', function () {
     $data = creator(ExampleFormRequestFactory::new()->state([
         'secret_identity' => ExampleFormRequestFactory::new()->state([

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -36,6 +36,13 @@ it('can alter attributes with the state method', function () {
         ->email->toBe('luke@downing.tech');
 });
 
+it('can alter nested properties using the state method and dot notation', function () {
+    $factory = ExampleFormRequestFactory::new()->state(['foo.bar' => 'baz']);
+    $data = creator($factory->state(['foo.bar' => 'boom']));
+
+    expect($data['foo']['bar'])->toBe('boom');
+});
+
 it('can resolve nested form request factories', function () {
     $data = creator(ExampleFormRequestFactory::new()->state([
         'secret_identity' => ExampleFormRequestFactory::new()->state([


### PR DESCRIPTION
Based on discussion #9, this PR allows a user to set a deeply nested array value using the `state` method.

```php
$data = MyRequestFactory::new()->state(['address.line_one' => '1 Test Street'])->create();
```

@dcaswel can you please verify that this solves your use case?