### PR TITLE
Adds support for custom Faker instances

### DIFF
--- a/src/RequestFactoriesServiceProvider.php
+++ b/src/RequestFactoriesServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Worksome\RequestFactories;
 
+use Faker\Generator;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\ServiceProvider;
 use Worksome\RequestFactories\Actions\CreateFactoryResult;
@@ -30,6 +31,10 @@ final class RequestFactoriesServiceProvider extends ServiceProvider
         $this->publishes($this->filesToPublish(), 'request-factories');
 
         $this->mergeConfigFrom(__DIR__ . '/../config/request-factories.php', 'request-factories');
+
+        if ($this->app->has(Generator::class)) {
+            RequestFactory::setFakerResolver(fn () => $this->app->make(Generator::class));
+        }
 
         if ($this->app->runningUnitTests()) {
             $this->app['events']->listen(RouteMatched::class, Listeners\MergeFactoryIntoRequest::class);

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -17,6 +17,11 @@ use Worksome\RequestFactories\Support\FactoryData;
 
 abstract class RequestFactory
 {
+    /**
+     * @var (Closure(): Generator)|null
+     */
+    private static Closure|null $fakerResolver = null;
+
     protected Generator $faker;
 
     /**
@@ -28,7 +33,15 @@ abstract class RequestFactory
         protected array $without = [],
         protected array $afterCreatingHooks = [],
     ) {
-        $this->faker = Factory::create();
+        $this->faker = $this->withFaker();
+    }
+
+    /**
+     * @param Closure(): Generator $resolver
+     */
+    public static function setFakerResolver(Closure $resolver): void
+    {
+        self::$fakerResolver = $resolver;
     }
 
     public static function new(array $attributes = []): static
@@ -156,6 +169,11 @@ abstract class RequestFactory
             array_merge($this->without, $without),
             array_merge($this->afterCreatingHooks, $afterCreatingHooks),
         );
+    }
+
+    protected function withFaker(): Generator
+    {
+        return self::$fakerResolver ? (self::$fakerResolver)() : Factory::create();
     }
 
     public function getFactoryData(): FactoryData

--- a/tests/Doubles/Factories/ExampleFormRequestFactory.php
+++ b/tests/Doubles/Factories/ExampleFormRequestFactory.php
@@ -62,4 +62,9 @@ final class ExampleFormRequestFactory extends RequestFactory
     {
         return $this->state(['profession' => $profession]);
     }
+
+    public function withFakerPhoneNumber()
+    {
+        return $this->state(['number' => $this->faker->e164PhoneNumber]);
+    }
 }

--- a/tests/Doubles/Factories/ExampleFormRequestFactory.php
+++ b/tests/Doubles/Factories/ExampleFormRequestFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Worksome\RequestFactories\Tests\Doubles\Factories;
 
 use Closure;
+use Faker\Generator;
 use Worksome\RequestFactories\RequestFactory;
 
 final class ExampleFormRequestFactory extends RequestFactory
@@ -63,8 +64,8 @@ final class ExampleFormRequestFactory extends RequestFactory
         return $this->state(['profession' => $profession]);
     }
 
-    public function withFakerPhoneNumber()
+    public function faker(): Generator
     {
-        return $this->state(['number' => $this->faker->e164PhoneNumber]);
+        return $this->faker;
     }
 }

--- a/tests/Feature/RequestFactoryTest.php
+++ b/tests/Feature/RequestFactoryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Faker\Generator;
+use Faker\Factory;
+use Worksome\RequestFactories\Tests\Doubles\Factories\ExampleFormRequestFactory;
+
+it('uses the laravel faker instance', function () {
+    $this->app->instance(Generator::class, Factory::create('en_GB'));
+    $data = ExampleFormRequestFactory::new()->withFakerPhoneNumber()->create();
+
+    expect($data['number'])->toStartWith('+44');
+});

--- a/tests/Feature/RequestFactoryTest.php
+++ b/tests/Feature/RequestFactoryTest.php
@@ -3,12 +3,12 @@
 declare(strict_types=1);
 
 use Faker\Generator;
-use Faker\Factory;
 use Worksome\RequestFactories\Tests\Doubles\Factories\ExampleFormRequestFactory;
 
 it('uses the laravel faker instance', function () {
-    $this->app->instance(Generator::class, Factory::create('en_GB'));
-    $data = ExampleFormRequestFactory::new()->withFakerPhoneNumber()->create();
+    $testGenerator = new class extends Generator {
+    };
+    $this->app->instance(Generator::class, $testGenerator);
 
-    expect($data['number'])->toStartWith('+44');
+    expect(ExampleFormRequestFactory::new()->faker())->toBe($testGenerator);
 });

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -3,7 +3,13 @@
 declare(strict_types=1);
 
 use Illuminate\Http\UploadedFile;
+use Worksome\RequestFactories\RequestFactory;
 use Worksome\RequestFactories\Tests\Doubles\Factories\ExampleFormRequestFactory;
+use Faker\Factory;
+
+beforeEach(function () {
+    RequestFactory::setFakerResolver(fn () => Factory::create());
+});
 
 it('can generate an array of data', function () {
     $createdData = creator(ExampleFormRequestFactory::new());
@@ -143,4 +149,15 @@ it('can overwrite deeply nested array data', function () {
 
     expect($data)->toHaveKeys(['work.name', 'work.position'])
         ->work->position->toBe('Software Engineer');
+});
+
+it('can set a custom faker instance', function () {
+    ExampleFormRequestFactory::setFakerResolver(fn () => Factory::create('en_GB'));
+    $english = creator(ExampleFormRequestFactory::new()->withFakerPhoneNumber());
+
+    ExampleFormRequestFactory::setFakerResolver(fn () => Factory::create());
+    $american = creator(ExampleFormRequestFactory::new()->withFakerPhoneNumber());
+
+    expect($english['number'])->toStartWith('+44')
+        ->and($american['number'])->toStartWith('+1');
 });

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -152,12 +152,12 @@ it('can overwrite deeply nested array data', function () {
 });
 
 it('can set a custom faker instance', function () {
-    ExampleFormRequestFactory::setFakerResolver(fn () => Factory::create('en_GB'));
-    $english = creator(ExampleFormRequestFactory::new()->withFakerPhoneNumber());
+    $testGenerator = new class extends \Faker\Generator {
+    };
 
-    ExampleFormRequestFactory::setFakerResolver(fn () => Factory::create());
-    $american = creator(ExampleFormRequestFactory::new()->withFakerPhoneNumber());
+    ExampleFormRequestFactory::setFakerResolver(fn () => $testGenerator);
+    expect(ExampleFormRequestFactory::new()->faker())->toBe($testGenerator);
 
-    expect($english['number'])->toStartWith('+44')
-        ->and($american['number'])->toStartWith('+1');
+    ExampleFormRequestFactory::setFakerResolver(fn () => Factory::create('en_US'));
+    expect(ExampleFormRequestFactory::new()->faker())->not->toBe($testGenerator);
 });


### PR DESCRIPTION
A different implementation of #20 that avoids reaching for the Laravel container inside the `RequestFactory` constructor.