### PR TITLE
Allows passing an instance of self to the request factory `::new` method.

### DIFF
--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -44,6 +44,10 @@ abstract class RequestFactory
         self::$fakerResolver = $resolver;
     }
 
+    /**
+     * @param array|static $attributes
+     * @return static
+     */
     public static function new(array|self $attributes = []): static
     {
         /**
@@ -51,7 +55,7 @@ abstract class RequestFactory
          * factories to work with depending on the complexity of the test. Here
          * we avoid having to conditionally check for an array of factory.
          */
-        if ($attributes instanceof self) {
+        if ($attributes instanceof static) {
             return $attributes;
         }
 

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -52,10 +52,14 @@ abstract class RequestFactory
         /**
          * When working with datasets, you may have a mixture of plain arrays and
          * factories to work with depending on the complexity of the test. Here
-         * we avoid having to conditionally check for an array or factory.
+         * we avoid having to manually check for an array or factory instance.
          */
         if ($attributes instanceof static) {
-            return $attributes;
+            return new static(
+                $attributes->attributes,
+                $attributes->without,
+                $attributes->afterCreatingHooks
+            );
         }
 
         return (new static())->state($attributes)->configure();

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -53,7 +53,7 @@ abstract class RequestFactory
         /**
          * When working with datasets, you may have a mixture of plain arrays and
          * factories to work with depending on the complexity of the test. Here
-         * we avoid having to conditionally check for an array of factory.
+         * we avoid having to conditionally check for an array or factory.
          */
         if ($attributes instanceof static) {
             return $attributes;

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -45,8 +45,7 @@ abstract class RequestFactory
     }
 
     /**
-     * @param array|static $attributes
-     * @return static
+     * @param array<string, mixed>|static $attributes
      */
     public static function new(array|self $attributes = []): static
     {

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -44,8 +44,17 @@ abstract class RequestFactory
         self::$fakerResolver = $resolver;
     }
 
-    public static function new(array $attributes = []): static
+    public static function new(array|self $attributes = []): static
     {
+        /**
+         * When working with datasets, you may have a mixture of plain arrays and
+         * factories to work with depending on the complexity of the test. Here
+         * we avoid having to conditionally check for an array of factory.
+         */
+        if ($attributes instanceof self) {
+            return $attributes;
+        }
+
         return (new static())->state($attributes)->configure();
     }
 

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -8,7 +8,7 @@ use Worksome\RequestFactories\Tests\Doubles\Factories\ExampleFormRequestFactory;
 use Faker\Factory;
 
 beforeEach(function () {
-    RequestFactory::setFakerResolver(fn () => Factory::create());
+    RequestFactory::setFakerResolver(fn() => Factory::create());
 });
 
 it('can generate an array of data', function () {
@@ -26,9 +26,13 @@ it('can generate an array of data', function () {
 });
 
 it('can receive an instance of itself when instantiating', function () {
-    $data = creator(ExampleFormRequestFactory::new(ExampleFormRequestFactory::new(['foo' => 'bar'])));
+    $data = creator(ExampleFormRequestFactory::new(
+        ExampleFormRequestFactory::new(['foo' => 'bar'])->without(['email'])
+    ));
 
-    expect($data['foo'])->toBe('bar');
+    expect($data)
+        ->not->toHaveKey('email')
+        ->foo->toBe('bar');
 });
 
 it('can provide attributes when instantiating', function () {
@@ -87,7 +91,7 @@ it('can resolve nested form request factories', function () {
 it('can resolve property closures, and passes those closures all other parameters', function () {
     $data = creator(ExampleFormRequestFactory::new()->state([
         'name' => 'Luke Downing',
-        'description' => fn (array $attributes) => "Hello, my name is {$attributes['name']}"
+        'description' => fn(array $attributes) => "Hello, my name is {$attributes['name']}"
     ]));
 
     expect($data['description'])->toBe('Hello, my name is Luke Downing');
@@ -110,7 +114,7 @@ it('allows the user to configure the factory', function () {
      * on ExampleFormRequestFactory to override the functionality.
      */
     ExampleFormRequestFactory::configureUsing(function (ExampleFormRequestFactory $factory) {
-        return $factory->afterCreating(fn () => ['foo' => 'bar']);
+        return $factory->afterCreating(fn() => ['foo' => 'bar']);
     });
 
     expect(creator(ExampleFormRequestFactory::new())->all())->toBe(['foo' => 'bar']);
@@ -161,9 +165,9 @@ it('can set a custom faker instance', function () {
     $testGenerator = new class extends \Faker\Generator {
     };
 
-    ExampleFormRequestFactory::setFakerResolver(fn () => $testGenerator);
+    ExampleFormRequestFactory::setFakerResolver(fn() => $testGenerator);
     expect(ExampleFormRequestFactory::new()->faker())->toBe($testGenerator);
 
-    ExampleFormRequestFactory::setFakerResolver(fn () => Factory::create('en_US'));
+    ExampleFormRequestFactory::setFakerResolver(fn() => Factory::create('en_US'));
     expect(ExampleFormRequestFactory::new()->faker())->not->toBe($testGenerator);
 });

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -25,6 +25,12 @@ it('can generate an array of data', function () {
     ]);
 });
 
+it('can receive an instance of itself when instantiating', function () {
+    $data = creator(ExampleFormRequestFactory::new(ExampleFormRequestFactory::new(['foo' => 'bar'])));
+
+    expect($data['foo'])->toBe('bar');
+});
+
 it('can provide attributes when instantiating', function () {
     $data = creator(ExampleFormRequestFactory::new(['name' => 'Luke Downing']));
 


### PR DESCRIPTION
Let's say you're testing validation (I may or may not be giving a talk on this topic 😉) using request factories.

To keep things clean, you're using a [dataset](https://pestphp.com/docs/datasets) with an array of `$data` and an array of expected `$errors`:

```php
it('requires valid data', function ($data, array $errors) {
    post(
        route('movies.store'), 
        StoreMovieRequestFactory::new($data)->create($data)
    )->assertInvalid($errors);
})->with([
    'the name is not a string' => [['name' => 1], ['name' => 'string']],
    'the name is longer than 255 chars' => [['name' => str_repeat('a', 256)], ['name' => '255 characters']],
    'the rating is not a supported enum value' => [['rating' => 'foo'], ['rating' => 'invalid']],
]);
```

Now, suppose one dataset item has more complex logic, and it would be far easier to reach for a factory. Currently, you'd have to use conditional logic in your test like so:

```php
it('requires valid data', function ($data, array $errors) {
   $payload = is_array($data) ? StoreMovieRequestFactory::new($data) : $data;

    post(
        route('movies.store'), 
        $payload->create($data)
    )->assertInvalid($errors);
})->with([
    'the name is not a string' => [['name' => 1], ['name' => 'string']],
    'the name is longer than 255 chars' => [['name' => str_repeat('a', 256)], ['name' => '255 characters']],
    'the rating is not a supported enum value' => [['rating' => 'foo'], ['rating' => 'invalid']],
    'something more complex' => [StoreMovieRequestFactory::new()->withComplexThing(), ['complex' => 'invalid]],
]);
```

With this PR, you no longer need to perform any conditional logic. Instead, we'll do that for you. If you pass a request factory to 

```php
it('requires valid data', function ($data, array $errors) {
    post(
        route('movies.store'), 
        StoreMovieRequestFactory::new($data)->create($data)
    )->assertInvalid($errors);
})->with([
    'the name is not a string' => [['name' => 1], ['name' => 'string']],
    'the name is longer than 255 chars' => [['name' => str_repeat('a', 256)], ['name' => '255 characters']],
    'the rating is not a supported enum value' => [['rating' => 'foo'], ['rating' => 'invalid']],
    'something more complex' => [StoreMovieRequestFactory::new()->withComplexThing(), ['complex' => 'invalid]],
]);
```