### PR TITLE
Adds `image` as a new helper method inside the factory.

### DIFF
--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -165,6 +165,11 @@ abstract class RequestFactory
         return UploadedFile::fake()->create($name);
     }
 
+    protected function image(string $name, int $width = 10, int $height = 10): File
+    {
+        return $this->file()->image($name, $width, $height);
+    }
+
     protected function faker(): Generator
     {
         return $this->faker;

--- a/tests/Doubles/Factories/ExampleFormRequestFactory.php
+++ b/tests/Doubles/Factories/ExampleFormRequestFactory.php
@@ -22,7 +22,7 @@ final class ExampleFormRequestFactory extends RequestFactory
                 'name' => $this->faker()->company,
                 'position' => $this->faker()->jobTitle,
             ],
-            'banner_image' => $this->file()->image('banner.png'),
+            'banner_image' => $this->image('banner.png'),
         ];
     }
 


### PR DESCRIPTION
This PR adds just a tiny bit of syntactic sugar when working with image files inside request factory methods.

```php
// before...
public function definition(): array
{
  return [
    'image' => $this->file()->image('foo.png'),
  ];
}

// after...
public function definition(): array
{
  return [
    'image' => $this->image('foo.png'),
  ];
}
```