### PR TITLE
Adds support for nested arrays and lazily resolving model factories.

### DIFF
--- a/src/Actions/CreateFactoryResult.php
+++ b/src/Actions/CreateFactoryResult.php
@@ -28,8 +28,8 @@ final class CreateFactoryResult implements CreatesFactoryResult
             ->through([
                 RecursiveStep::using(new ResolveNestedRequestFactories($this)),
                 RecursiveStep::using(new ResolveClosures()),
-                RecursiveStep::using(new ResolveModelFactories()),
                 new RemoveWithout($data->getWithout()),
+                RecursiveStep::using(new ResolveModelFactories()),
                 new InvokeAfterCreatingHooks($data->getAfterCreatingHooks()),
             ])
             ->thenReturn();

--- a/src/Actions/CreateFactoryResult.php
+++ b/src/Actions/CreateFactoryResult.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Worksome\RequestFactories\Actions;
 
-use Illuminate\Routing\Pipeline;
+use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
 use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\InvokeAfterCreatingHooks;
+use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\RecursiveStep;
 use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\RemoveWithout;
 use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\ResolveClosures;
-use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\ResolveNestedFactories;
+use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\ResolveModelFactories;
+use Worksome\RequestFactories\Actions\CreateFactoryResultSteps\ResolveNestedRequestFactories;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
 use Worksome\RequestFactories\RequestFactory;
 use Worksome\RequestFactories\Support\Result;
@@ -24,8 +26,9 @@ final class CreateFactoryResult implements CreatesFactoryResult
         $result = (new Pipeline())
             ->send(collect($data->getRequestedData()))
             ->through([
-                new ResolveNestedFactories($this),
-                new ResolveClosures(),
+                RecursiveStep::using(new ResolveNestedRequestFactories($this)),
+                RecursiveStep::using(new ResolveClosures()),
+                RecursiveStep::using(new ResolveModelFactories()),
                 new RemoveWithout($data->getWithout()),
                 new InvokeAfterCreatingHooks($data->getAfterCreatingHooks()),
             ])

--- a/src/Actions/CreateFactoryResultSteps/InvokeAfterCreatingHooks.php
+++ b/src/Actions/CreateFactoryResultSteps/InvokeAfterCreatingHooks.php
@@ -6,14 +6,15 @@ namespace Worksome\RequestFactories\Actions\CreateFactoryResultSteps;
 
 use Closure;
 use Illuminate\Support\Collection;
+use Worksome\RequestFactories\Contracts\Actions\CreateFactoryResultStep;
 
-final class InvokeAfterCreatingHooks
+final class InvokeAfterCreatingHooks implements CreateFactoryResultStep
 {
     public function __construct(private array $hooks)
     {
     }
 
-    public function handle(Collection $data, Closure $next): mixed
+    public function handle(Collection $data, Closure $next): Collection
     {
         $data = collect($this->hooks)->reduce(
             // @phpstan-ignore-next-line

--- a/src/Actions/CreateFactoryResultSteps/RecursiveStep.php
+++ b/src/Actions/CreateFactoryResultSteps/RecursiveStep.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Actions\CreateFactoryResultSteps;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Worksome\RequestFactories\Contracts\Actions\CreateFactoryResultStep;
+
+final class RecursiveStep implements CreateFactoryResultStep
+{
+    private function __construct(private CreateFactoryResultStep $decoratedStep)
+    {
+    }
+
+    public static function using(CreateFactoryResultStep $decoratedStep): self
+    {
+        return new self($decoratedStep);
+    }
+
+    public function handle(Collection $data, Closure $next): Collection
+    {
+        return $this->decoratedStep->handle(
+            $data->map(fn(mixed $item) => $this->walk($item)),
+            $next,
+        );
+    }
+
+    private function walk(mixed $data): mixed
+    {
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        $data = Collection::make($data)->map(fn (mixed $item) => $this->walk($item));
+
+        return $this
+            ->decoratedStep
+            ->handle($data, fn (Collection $alteredData) => $alteredData)
+            ->all();
+    }
+}

--- a/src/Actions/CreateFactoryResultSteps/RemoveWithout.php
+++ b/src/Actions/CreateFactoryResultSteps/RemoveWithout.php
@@ -7,8 +7,9 @@ namespace Worksome\RequestFactories\Actions\CreateFactoryResultSteps;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Worksome\RequestFactories\Contracts\Actions\CreateFactoryResultStep;
 
-final class RemoveWithout
+final class RemoveWithout implements CreateFactoryResultStep
 {
     /**
      * @param array<int, string> $without
@@ -20,7 +21,7 @@ final class RemoveWithout
     /**
      * @param Collection<mixed> $data
      */
-    public function handle(Collection $data, Closure $next): mixed
+    public function handle(Collection $data, Closure $next): Collection
     {
         $data = $data->all();
         Arr::forget($data, $this->without);

--- a/src/Actions/CreateFactoryResultSteps/ResolveModelFactories.php
+++ b/src/Actions/CreateFactoryResultSteps/ResolveModelFactories.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Worksome\RequestFactories\Actions\CreateFactoryResultSteps;
 
 use Closure;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Collection;
 use Worksome\RequestFactories\Contracts\Actions\CreateFactoryResultStep;
 
-final class ResolveClosures implements CreateFactoryResultStep
+class ResolveModelFactories implements CreateFactoryResultStep
 {
     public function handle(Collection $data, Closure $next): Collection
     {
-        $data = $data->map(fn (mixed $item) => $item instanceof Closure
-            ? $item($data->all())
+        $data = $data->map(fn (mixed $item) => $item instanceof Factory
+            ? $item->createOne()->getKey()
             : $item);
 
         return $next($data);

--- a/src/Actions/CreateFactoryResultSteps/ResolveNestedRequestFactories.php
+++ b/src/Actions/CreateFactoryResultSteps/ResolveNestedRequestFactories.php
@@ -6,16 +6,17 @@ namespace Worksome\RequestFactories\Actions\CreateFactoryResultSteps;
 
 use Closure;
 use Illuminate\Support\Collection;
+use Worksome\RequestFactories\Contracts\Actions\CreateFactoryResultStep;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
 use Worksome\RequestFactories\RequestFactory;
 
-final class ResolveNestedFactories
+final class ResolveNestedRequestFactories implements CreateFactoryResultStep
 {
     public function __construct(private CreatesFactoryResult $createFactoryResult)
     {
     }
 
-    public function handle(Collection $data, Closure $next): mixed
+    public function handle(Collection $data, Closure $next): Collection
     {
         $data = $data->map(fn (mixed $item) => $item instanceof RequestFactory
             ? $this->createFactoryResult->__invoke($item)->all()

--- a/src/Contracts/Actions/CreateFactoryResultStep.php
+++ b/src/Contracts/Actions/CreateFactoryResultStep.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Contracts\Actions;
+
+use Closure;
+use Illuminate\Support\Collection;
+
+interface CreateFactoryResultStep
+{
+    /**
+     * @param Collection<mixed> $data
+     * @param Closure(Collection<mixed>): Collection<mixed> $next
+     * @return Collection<mixed>
+     */
+    public function handle(Collection $data, Closure $next): Collection;
+}

--- a/tests/Doubles/Factories/ModelFactoryRequestFactory.php
+++ b/tests/Doubles/Factories/ModelFactoryRequestFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Tests\Doubles\Factories;
+
+use Worksome\RequestFactories\RequestFactory;
+use Worksome\RequestFactories\Tests\Doubles\Factories\Models\UserFactory;
+
+class ModelFactoryRequestFactory extends RequestFactory
+{
+    public function definition(): array
+    {
+        return [
+            'model' => UserFactory::new(),
+            'nested' => [
+                'model' => UserFactory::new(),
+            ],
+        ];
+    }
+}

--- a/tests/Doubles/Factories/Models/User.php
+++ b/tests/Doubles/Factories/Models/User.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Tests\Doubles\Factories\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+}

--- a/tests/Doubles/Factories/Models/UserFactory.php
+++ b/tests/Doubles/Factories/Models/UserFactory.php
@@ -21,6 +21,11 @@ class UserFactory extends Factory
         ];
     }
 
+    public static function resetId(): void
+    {
+        self::$id = 1;
+    }
+
     /**
      * We override this method because we want to avoid having to do
      * any database setup for testing this package. The ID will

--- a/tests/Doubles/Factories/Models/UserFactory.php
+++ b/tests/Doubles/Factories/Models/UserFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Tests\Doubles\Factories\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class UserFactory extends Factory
+{
+    private static int $id = 1;
+    protected $model = User::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => 'Luke Downing',
+            'description' => 'Laravel developer',
+        ];
+    }
+
+    /**
+     * We override this method because we want to avoid having to do
+     * any database setup for testing this package. The ID will
+     * simply be set to the auto-incrementing ID.
+     */
+    protected function store(Collection $results): void
+    {
+        $results->each(fn(Model $model, int $key) => $model->{$model->getKeyName()} = self::$id++);
+    }
+}

--- a/tests/Doubles/Factories/NestedArrayRequestFactory.php
+++ b/tests/Doubles/Factories/NestedArrayRequestFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\RequestFactories\Tests\Doubles\Factories;
+
+use Worksome\RequestFactories\RequestFactory;
+
+class NestedArrayRequestFactory extends RequestFactory
+{
+    public function definition(): array
+    {
+        return [
+            'foo' => [
+                'bar' => fn () => 'baz',
+                'baz' => [
+                    'boom' => [
+                        'bang' => fn () => 'whizz',
+                    ]
+                ],
+                'factory' => AddressFormRequestFactory::new(),
+            ]
+        ];
+    }
+}

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -6,6 +6,8 @@ use Illuminate\Http\UploadedFile;
 use Worksome\RequestFactories\RequestFactory;
 use Worksome\RequestFactories\Tests\Doubles\Factories\ExampleFormRequestFactory;
 use Faker\Factory;
+use Worksome\RequestFactories\Tests\Doubles\Factories\ModelFactoryRequestFactory;
+use Worksome\RequestFactories\Tests\Doubles\Factories\NestedArrayRequestFactory;
 
 beforeEach(function () {
     RequestFactory::setFakerResolver(fn() => Factory::create());
@@ -170,4 +172,31 @@ it('can set a custom faker instance', function () {
 
     ExampleFormRequestFactory::setFakerResolver(fn() => Factory::create('en_US'));
     expect(ExampleFormRequestFactory::new()->faker())->not->toBe($testGenerator);
+});
+
+it('can recursively resolve closures', function () {
+    $data = creator(NestedArrayRequestFactory::new());
+
+    expect($data['foo']['bar'])->toBe('baz');
+    expect($data['foo']['baz']['boom']['bang'])->toBe('whizz');
+});
+
+it('can recursively resolve request factories', function () {
+    $data = creator(NestedArrayRequestFactory::new());
+
+    expect($data['foo']['factory'])
+        ->toBeArray()
+        ->toHaveKeys(['line_one', 'line_two', 'city', 'country']);
+});
+
+it('can resolve model factories', function () {
+    $data = creator(ModelFactoryRequestFactory::new());
+
+    /**
+     * Nested will have the lower ID because it is resolved by the factory
+     * first, due to recursive arrays being handled inside-out.
+     */
+    expect($data)
+        ->nested->model->toBe(1)
+        ->model->toBe(2);
 });

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -7,10 +7,12 @@ use Worksome\RequestFactories\RequestFactory;
 use Worksome\RequestFactories\Tests\Doubles\Factories\ExampleFormRequestFactory;
 use Faker\Factory;
 use Worksome\RequestFactories\Tests\Doubles\Factories\ModelFactoryRequestFactory;
+use Worksome\RequestFactories\Tests\Doubles\Factories\Models\UserFactory;
 use Worksome\RequestFactories\Tests\Doubles\Factories\NestedArrayRequestFactory;
 
 beforeEach(function () {
     RequestFactory::setFakerResolver(fn() => Factory::create());
+    UserFactory::resetId();
 });
 
 it('can generate an array of data', function () {
@@ -199,4 +201,15 @@ it('can resolve model factories', function () {
     expect($data)
         ->nested->model->toBe(1)
         ->model->toBe(2);
+});
+
+it('resolves model factories after handling attributes declared in ::without', function () {
+    $data = creator(ModelFactoryRequestFactory::new()->without(['nested.model']));
+
+    /**
+     * If you look at the previous test, you'll see that the nested model is handled
+     * before the base model. However, when removed from the request using `without`,
+     * it should never have been executed and thus our ID for `model` should be 1.
+     */
+    expect($data->model)->toBe(1);
 });


### PR DESCRIPTION
So, currently request factories are shallow. I know, it hurts to say, but it's true. Basically, if you have something like this:

```php
public function definition(): array
{
    return [
        'foo' => [
            'bar' => fn () => 'baz',
            'baz' => [
                'boom' => [
                    'bang' => fn () => 'whizz',
                ]
            ],
            'factory' => AddressFormRequestFactory::new(),
        ]
    ];
}
```

then `foo.bar` will still be a `Closure` and `foo.factory` will still be a `AddressFormRequestFactory`.

This PR solves that by checking recursively for request factories, closures and model factories. *Model factories you say?* Yes, because this PR also adds model factories as first class citizens, allowing you to write something like this in your request factory definition:

```php
public function definition(): array
{
    return [
        'foo' => User::factory()
    ];
}
```

The model factory is created lazily, so no database row is inserted if the key is overridden by the developer using `state` or another data alteration method. We also remove any attributes declared using `::without()` before resolving model factories, again avoiding creating database entries for no valid reason. 

Kind Regards,
Luke