### PR TITLE
Adds support for passing a string to without.

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,13 +291,15 @@ from the request? Try the `without` method!
 
 ```php
 it('requires an email address', function () {
-    SignupRequest::factory()->without(['email'])->fake();
+    SignupRequest::factory()->without('email')->fake();
     
     $this->put('/users')->assertInvalid(['email' => 'required']);
 });
 ```
 
 > 💡 You can use dot syntax in the `without` method to unset deeply nested keys
+
+You can also pass an array to `without` to unset multiple properties at once.
 
 Sometimes, you'll have a property that you want to be based on the value of other properties.
 In that case, you can provide a closure as the property value, which receives an array of all other parameters:

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -10,6 +10,7 @@ use Faker\Generator;
 use Illuminate\Http\Testing\File;
 use Illuminate\Http\Testing\FileFactory;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
 use Worksome\RequestFactories\Actions\UndotArrayKeys;
 use Worksome\RequestFactories\Contracts\Actions\CreatesFactoryResult;
 use Worksome\RequestFactories\Contracts\Actions\UndotsArrayKeys;
@@ -110,11 +111,11 @@ abstract class RequestFactory
      * request. You can use dot syntax here to unset deeply nested
      * keys in request data.
      *
-     * @param array<int, string> $attributes
+     * @param array<int, string>|string $attributes
      */
-    public function without(array $attributes): static
+    public function without(array|string $attributes): static
     {
-        return $this->newInstance(without: $attributes);
+        return $this->newInstance(without: Arr::wrap($attributes));
     }
 
     /**

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -150,11 +150,14 @@ it('is iterable', function () {
     expect($data)->toBeIterable();
 });
 
-it('can unset keys using dot notation', function () {
-    $data = creator(ExampleFormRequestFactory::new()->without(['name', 'address.line_one']));
+it('can unset keys using dot notation', function ($without, array $expectedMissingKeys) {
+    $data = creator(ExampleFormRequestFactory::new()->without($without));
 
-    expect($data)->not->toHaveKeys(['name', 'address.line_one']);
-});
+    expect($data)->not->toHaveKeys($expectedMissingKeys);
+})->with([
+    'string' => ['address.line_one', ['address.line_one']],
+    'array' => [['name', 'address.line_one'], ['name', 'address.line_one']]
+]);
 
 it('can overwrite deeply nested array data', function () {
     $data = creator(ExampleFormRequestFactory::new()->state([


### PR DESCRIPTION
Small QOL improvement. Most of the time, you only want to unset a single item using `without`, so I thought it would be nice to accept a string as well as an array.