### PR TITLE
chore(deps): Laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2]
-        laravel: [9.*]
+        laravel: [9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -40,6 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^9.46|^10.0",
-        "laravel/framework": "10.*"
+        "illuminate/contracts": "^9.46|^10.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,13 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^9.46"
+        "illuminate/contracts": "^9.46|^10.0",
+        "laravel/framework": "10.*"
     },
     "require-dev": {
         "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^2.0",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "worksome/pest-plugin-silence": "^0.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     build: ./docker
     volumes:
       - .:/var/www/html
+    environment:
+      - XDEBUG_MODE=${XDEBUG_MODE:-off}
+      - XDEBUG_CONFIG=${XDEBUG_CONFIG:-client_host=host.docker.internal}
   pest:
     build: ./docker
     entrypoint: ["php", "./vendor/bin/pest"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,16 @@
 FROM php:8.2-cli
 
-RUN pecl install pcov
+RUN pecl install xdebug
 
 RUN apt-get update \
-    && apt-get install -y libpng-dev libjpeg-dev
+    && apt-get install -y libpng-dev libjpeg-dev libzip-dev zip
 
-RUN docker-php-ext-configure gd --with-jpeg \
-    && docker-php-ext-install gd \
-    && docker-php-ext-enable pcov
+RUN docker-php-ext-configure gd --with-jpeg
+RUN docker-php-ext-install gd
+
+RUN docker-php-ext-install zip
+
+RUN docker-php-ext-enable xdebug
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -12,8 +12,7 @@ use Worksome\RequestFactories\Contracts\Finder;
 
 final class MakeCommand extends GeneratorCommand
 {
-    public $signature = 'make:request-factory
-                         {name : The name of the request or request factory.}';
+    public $signature = 'make:request-factory {name : The name of the request or request factory.}';
 
     public $description = 'Generate a new FormRequest Factory.';
 

--- a/src/RequestFactoriesServiceProvider.php
+++ b/src/RequestFactoriesServiceProvider.php
@@ -30,8 +30,10 @@ final class RequestFactoriesServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        $this->commands(MakeCommand::class);
-        $this->publishes($this->filesToPublish(), 'request-factories');
+        if ($this->app->runningInConsole()) {
+            $this->commands([MakeCommand::class]);
+            $this->publishes($this->filesToPublish(), 'request-factories');
+        }
 
         $this->mergeConfigFrom(__DIR__ . '/../config/request-factories.php', 'request-factories');
 


### PR DESCRIPTION
Adds support for the upcoming release of Laravel 10.

Note that tests for Laravel 10 (and Laravel 9.49+) will fail until https://github.com/laravel/framework/pull/45864 is released because of a Laravel bug with the `GeneratorCommand`, which our `MakeCommand` uses. Once that PR is in, I will rerun CI and everything here should pass 👍

In debugging the Laravel bug, I found it useful to have support for Xdebug, so I've used this opportunity to add that to our Docker images. You can set the `XDEBUG_MODE` environment variable along with a relevant mode(s) when running PHP to make use of XDebug.