### PR TITLE
Added mixed return type to factory macro lambda function.

### DIFF
--- a/src/RequestFactoriesServiceProvider.php
+++ b/src/RequestFactoriesServiceProvider.php
@@ -67,7 +67,7 @@ final class RequestFactoriesServiceProvider extends ServiceProvider
 
         FormRequest::macro(
             'factory',
-            static fn() => app(Map::class)->formRequestToFactory(static::class)::new()
+            static fn(): mixed => app(Map::class)->formRequestToFactory(static::class)::new()
         );
     }
 


### PR DESCRIPTION
PhpStorm with the Idea plugin reports that the FormRequest `factory()` macro function returns void and thus underlines any chaining off the factory as an error.

This can be fixed by explicitly adding a return type of `mixed` to the factory macro's lambda function, which then keeps PhpStorm happy :)

![2023-05-20 14_23_57-Lead-Response – InstantFormControllerTest php  Lead-Response](https://github.com/worksome/request-factories/assets/334791/286e37ea-08f7-4ca6-81af-2e32fba37078)
