### PR TITLE
RequestFactory.php added override

### DIFF
--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -107,6 +107,14 @@ abstract class RequestFactory
     }
 
     /**
+     * Provide a key and value to override in the request data.
+     */
+    public function override(string $key, mixed $value): static
+    {
+        return $this->state([$key => $value]);
+    }
+
+    /**
      * Indicate that the given attributes should be omitted from the
      * request. You can use dot syntax here to unset deeply nested
      * keys in request data.


### PR DESCRIPTION
I have the use case where I just want to update one key in the form request and I don't want it to be like `$factory->without('foo)->override('bar', 123)`. So I created a PR for it.