### PR TITLE
Replaced map with reduce to pass changed values.

### DIFF
--- a/src/Actions/CreateFactoryResultSteps/ResolveClosures.php
+++ b/src/Actions/CreateFactoryResultSteps/ResolveClosures.php
@@ -12,9 +12,12 @@ final readonly class ResolveClosures implements CreateFactoryResultStep
 {
     public function handle(Collection $data, Closure $next): Collection
     {
-        $data = $data->map(fn (mixed $item) => $item instanceof Closure
-            ? $item($data->all())
-            : $item);
+        $data = $data->reduce(
+            fn(Collection $carry, mixed $item, mixed $key) => $carry->put($key, $item instanceof Closure
+                ? $item($carry->all())
+                : $item),
+            $data
+        );
 
         return $next($data);
     }


### PR DESCRIPTION
While using two or more dependent callback on define it was not passing already resolved data.

```
class UserStoreRequestFactory extends RequestFactory
{
    public function definition(): array
    {
        return [
            'name'       => $this->faker()->name,
            'status'     => 'active',
            'email'      => $this->faker()->email,
            'level'      => 1,
            'client_ids' => fn (array $data) => [1,2,3],
            'brand_ids'  => fn (array $data) => $this->getBrandIds(data['client_ids']),
        ];
    }
}

public function getBrandIds(array $clientIds)

```

It was throwing error  `Argument #1 ($clientIds) must be of type array, Closure given, called in`