### PR TITLE
Support Array of Files

### DIFF
--- a/src/Support/Result.php
+++ b/src/Support/Result.php
@@ -45,7 +45,7 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
      */
     public function input(): array
     {
-        return $this->filterAttributes($this->attributes, fn($attribute) => ! $attribute instanceof SplFileInfo);
+        return $this->filterAttributes($this->attributes, fn ($attribute) => ! $attribute instanceof SplFileInfo);
     }
 
     /**
@@ -55,7 +55,7 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
      */
     public function files(): array
     {
-        return $this->filterAttributes($this->attributes, fn($attribute) => $attribute instanceof SplFileInfo);
+        return $this->filterAttributes($this->attributes, fn ($attribute) => $attribute instanceof SplFileInfo);
     }
 
     public function hasFiles(): bool
@@ -120,8 +120,9 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
     /**
      * Recursively filters attributes based on the given callback.
      *
-     * @param array $attributes
+     * @param array    $attributes
      * @param callable $callback
+     *
      * @return array
      */
     private function filterAttributes(array $attributes, callable $callback): array
@@ -134,6 +135,7 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
                 $filtered[$key] = $value;
             }
         }
+
         return array_filter($filtered);
     }
 }

--- a/src/Support/Result.php
+++ b/src/Support/Result.php
@@ -116,4 +116,24 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
 
         return $this->all()[$name];
     }
+
+    /**
+     * Recursively filters attributes based on the given callback.
+     *
+     * @param array $attributes
+     * @param callable $callback
+     * @return array
+     */
+    private function filterAttributes(array $attributes, callable $callback): array
+    {
+        $filtered = [];
+        foreach ($attributes as $key => $value) {
+            if (is_array($value)) {
+                $filtered[$key] = $this->filterAttributes($value, $callback);
+            } elseif ($callback($value)) {
+                $filtered[$key] = $value;
+            }
+        }
+        return array_filter($filtered);
+    }
 }

--- a/src/Support/Result.php
+++ b/src/Support/Result.php
@@ -45,7 +45,7 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
      */
     public function input(): array
     {
-        return array_filter($this->attributes, fn ($attribute) => ! $attribute instanceof SplFileInfo);
+        return $this->filterAttributes($this->attributes, fn($attribute) => ! $attribute instanceof SplFileInfo);
     }
 
     /**
@@ -55,7 +55,7 @@ final readonly class Result implements Arrayable, ArrayAccess, IteratorAggregate
      */
     public function files(): array
     {
-        return array_filter($this->attributes, fn (mixed $attribute) => $attribute instanceof SplFileInfo);
+        return $this->filterAttributes($this->attributes, fn($attribute) => $attribute instanceof SplFileInfo);
     }
 
     public function hasFiles(): bool

--- a/tests/Unit/RequestFactoryTest.php
+++ b/tests/Unit/RequestFactoryTest.php
@@ -136,12 +136,31 @@ it('can extract files from the request', function () {
     }
 });
 
+it('can extract the array of files from the request', function () {
+    $data = creator(ExampleFormRequestFactory::new()->state([
+        'images' => [
+            UploadedFile::fake()->image('luke.png', 120, 120),
+            UploadedFile::fake()->image('downing.png', 120, 120),
+        ],
+    ]));
+
+    expect($data->files())->toHaveKey('images');
+    expect($data['images'])->toBeArray();
+    expect($data->files()['images'])->toBeArray();
+    for ($i = 0; $i < 2; $i++) {
+        expect($data['images'][$i])->toBeInstanceOf(UploadedFile::class);
+        expect($data->files()['images'][$i])->toBeInstanceOf(UploadedFile::class);
+    }
+});
+
 it('can return input without files', function () {
     $data = creator(ExampleFormRequestFactory::new()->state([
         'profile_picture' => UploadedFile::fake()->image('luke.png', 120, 120),
+        'images' => [UploadedFile::fake()->image('downing.png', 120, 120), ],
     ]));
 
     expect($data->input())->not->toHaveKey('profile_picture');
+    expect($data->input())->not->toHaveKey('images');
 });
 
 it('is iterable', function () {


### PR DESCRIPTION
It is not possible to have a request factory where a key has an array of files e.g.,:
```php

public function files(): array
{
    return [
        'documents' => [
            $this->image('file.jpg'),
            $this->image('file2.jpg'),
            $this->file('file.pdf'),
        ],
    ];
}
```

This PR adds support for this by updating the `Result.php` to adjust the filtering of `inputs()` and `files()` such that arrays of files are found in `files()` and NOT in `inputs()`. This does not appear to break existing tests and should be backwardly compatible.

This ensures that the files are passed correctly in the request and thus can be found by the controller.

I've adjusted the test suite to add new checks for the array of files, and existing tests continue to pass.